### PR TITLE
fix[CI]: harden Dokploy Prisma sync and use Blacksmith docker cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -482,7 +482,7 @@ jobs:
             '' \
             'echo "Checking schema drift between DB and Prisma schema..."' \
             'set +e' \
-            'bunx prisma migrate diff --from-url "$DATABASE_URL" --to-schema-datamodel "$SCHEMA_PATH" --exit-code >/dev/null' \
+            'bunx prisma migrate diff --from-config-datasource --to-schema "$SCHEMA_PATH" --config "$PRISMA_CONFIG_PATH" --exit-code >/dev/null' \
             'diff_status=$?' \
             'set -e' \
             '' \
@@ -521,6 +521,7 @@ jobs:
             -H 'accept: application/json' \
             -H 'Content-Type: application/json' \
             -H "x-api-key: ${DOKPLOY_API_TOKEN}" \
+            --fail-with-body \
             -d "$CREATE_PAYLOAD")
 
           SCHEDULE_ID=$(printf '%s' "$CREATE_RESPONSE" | jq -r '.scheduleId // .id // .data.scheduleId // empty')
@@ -536,6 +537,15 @@ jobs:
             -H 'accept: application/json' \
             -H 'Content-Type: application/json' \
             -H "x-api-key: ${DOKPLOY_API_TOKEN}" \
+            --fail-with-body \
             -d "{\"scheduleId\":\"${SCHEDULE_ID}\"}")
+
+          RUN_ERROR_CODE=$(printf '%s' "$RUN_RESPONSE" | jq -r '.code // .data.code // empty')
+
+          if [ -n "$RUN_ERROR_CODE" ]; then
+            echo "Dokploy schedule run failed with code: ${RUN_ERROR_CODE}"
+            printf '%s\n' "$RUN_RESPONSE"
+            exit 1
+          fi
 
           printf '%s\n' "$RUN_RESPONSE"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,8 +286,6 @@ jobs:
           file: ${{ matrix.dockerfile }}
           push: true
           platforms: linux/amd64,linux/arm64
-          cache-from: type=gha,scope=${{ matrix.image }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.image }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zephyr",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "license": "AGPL-3.0",
   "homepage": "https://zephyyrr.in",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zephyr",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "license": "AGPL-3.0",
   "homepage": "https://zephyyrr.in",
   "private": true,


### PR DESCRIPTION
## Summary
- fix Prisma safe-sync command to Prisma 7-compatible `migrate diff` flags (`--from-config-datasource` + `--to-schema`)
- fail fast if Dokploy schedule API returns an error payload instead of silently passing
- remove external `cache-from/cache-to` directives from Docker build step so Blacksmith native layer caching is used as intended

## Why
- main CI run failed in `Prisma safe sync` because `--from-url` is removed in current Prisma CLI
- Blacksmith docs recommend removing external docker cache directives when using `useblacksmith/setup-docker-builder` + `useblacksmith/build-push-action`

## Validation
- actionlint
- bun run check
- bun run check-types
- pre-push hooks (unit tests + types) passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Version Update**
  * Released version 1.0.25

* **Improvements**
  * Enhanced error detection and reporting for scheduled operations, improving system reliability
  * Optimized build pipeline configuration for faster and more efficient deployments
  * Strengthened database schema synchronization validation to ensure consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->