### PR TITLE
fix[CI]: finalize Dokploy Prisma runtime sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -470,10 +470,10 @@ jobs:
 
           PRISMA_COMMAND="$(printf '%s\n' \
             'set -eu' \
-            'cd /app' \
+            'cd /app/packages/db' \
             '' \
-            'PRISMA_CONFIG_PATH="packages/db/prisma.config.ts"' \
-            'SCHEMA_PATH="packages/db/prisma/schema.prisma"' \
+            'PRISMA_CONFIG_PATH="./prisma.config.ts"' \
+            'SCHEMA_PATH="./prisma/schema.prisma"' \
             '' \
             'echo "Applying committed Prisma migrations..."' \
             'bunx prisma migrate deploy --config "$PRISMA_CONFIG_PATH"' \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -513,7 +513,7 @@ jobs:
             'fi' \
             '' \
             'echo "Schema drift detected. Attempting non-destructive sync with db push..."' \
-            'bunx prisma db push --skip-generate --config "$TEMP_CONFIG"' \
+            'bunx prisma db push --config "$TEMP_CONFIG"' \
             '' \
             'echo "Prisma safe sync completed."' \
           )"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -470,17 +470,35 @@ jobs:
 
           PRISMA_COMMAND="$(printf '%s\n' \
             'set -eu' \
-            'cd /app/packages/db' \
+            'cd /app' \
             '' \
-            'PRISMA_CONFIG_PATH="./prisma.config.ts"' \
-            'SCHEMA_PATH="./prisma/schema.prisma"' \
+            'SCHEMA_PATH="/app/packages/db/prisma/schema.prisma"' \
+            'MIGRATIONS_PATH="/app/packages/db/prisma/migrations"' \
+            'TEMP_CONFIG="/tmp/zephyr-prisma.config.ts"' \
+            'DB_URL="${DATABASE_URL:-${POSTGRES_PRISMA_URL:-${POSTGRES_URL_NON_POOLING:-}}}"' \
+            '' \
+            'if [ -z "$DB_URL" ]; then' \
+            '  echo "No database URL found in DATABASE_URL/POSTGRES_PRISMA_URL/POSTGRES_URL_NON_POOLING"' \
+            '  exit 1' \
+            'fi' \
+            '' \
+            'export DATABASE_URL="$DB_URL"' \
+            '' \
+            'cat > "$TEMP_CONFIG" <<EOF' \
+            'import { defineConfig } from "prisma/config";' \
+            'export default defineConfig({' \
+            '  schema: "/app/packages/db/prisma/schema.prisma",' \
+            '  migrations: { path: "/app/packages/db/prisma/migrations" },' \
+            '  datasource: { url: process.env.DATABASE_URL ?? "" },' \
+            '});' \
+            'EOF' \
             '' \
             'echo "Applying committed Prisma migrations..."' \
-            'bunx prisma migrate deploy --config "$PRISMA_CONFIG_PATH"' \
+            'bunx prisma migrate deploy --config "$TEMP_CONFIG"' \
             '' \
             'echo "Checking schema drift between DB and Prisma schema..."' \
             'set +e' \
-            'bunx prisma migrate diff --from-config-datasource --to-schema "$SCHEMA_PATH" --config "$PRISMA_CONFIG_PATH" --exit-code >/dev/null' \
+            'bunx prisma migrate diff --from-config-datasource --to-schema "$SCHEMA_PATH" --config "$TEMP_CONFIG" --exit-code >/dev/null' \
             'diff_status=$?' \
             'set -e' \
             '' \
@@ -495,7 +513,7 @@ jobs:
             'fi' \
             '' \
             'echo "Schema drift detected. Attempting non-destructive sync with db push..."' \
-            'bunx prisma db push --skip-generate --config "$PRISMA_CONFIG_PATH"' \
+            'bunx prisma db push --skip-generate --config "$TEMP_CONFIG"' \
             '' \
             'echo "Prisma safe sync completed."' \
           )"
@@ -530,15 +548,24 @@ jobs:
             exit 1
           fi
 
-          RUN_RESPONSE=$(curl -sS -X 'POST' \
+          RUN_RESPONSE_FILE=$(mktemp)
+          RUN_STATUS=$(curl -sS -o "$RUN_RESPONSE_FILE" -w "%{http_code}" -X 'POST' \
             "${API_URL}/api/schedule.runManually" \
             -H 'accept: application/json' \
             -H 'Content-Type: application/json' \
             -H "x-api-key: ${DOKPLOY_API_TOKEN}" \
-            --fail-with-body \
             -d "{\"scheduleId\":\"${SCHEDULE_ID}\"}")
 
-          RUN_ERROR_CODE=$(printf '%s' "$RUN_RESPONSE" | jq -r '.code // .data.code // empty')
+          RUN_RESPONSE=$(cat "$RUN_RESPONSE_FILE")
+          rm -f "$RUN_RESPONSE_FILE"
+
+          if [ "$RUN_STATUS" -ge 400 ]; then
+            echo "Dokploy schedule run request failed with HTTP ${RUN_STATUS}"
+            printf '%s\n' "$RUN_RESPONSE"
+            exit 1
+          fi
+
+          RUN_ERROR_CODE=$(printf '%s' "$RUN_RESPONSE" | jq -r 'if type == "object" then (.code // .data.code // empty) else empty end' 2>/dev/null || true)
 
           if [ -n "$RUN_ERROR_CODE" ]; then
             echo "Dokploy schedule run failed with code: ${RUN_ERROR_CODE}"

--- a/.github/workflows/rustfs-buckets.yml
+++ b/.github/workflows/rustfs-buckets.yml
@@ -17,16 +17,13 @@ jobs:
     name: Ensure RustFS buckets and policies
     runs-on: ubuntu-latest
     steps:
-      - name: Configure AWS credentials for RustFS
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.RUSTFS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.RUSTFS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.RUSTFS_REGION }}
-
       - name: Ensure buckets, policies, and versioning
         env:
           RUSTFS_ENDPOINT: ${{ secrets.RUSTFS_S3_ENDPOINT }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.RUSTFS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.RUSTFS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.RUSTFS_REGION }}
+          AWS_EC2_METADATA_DISABLED: "true"
           APPLY_PUBLIC_POLICIES: ${{ github.event.inputs.apply_public_policies || 'true' }}
           ENABLE_VERSIONING: ${{ github.event.inputs.enable_versioning || 'true' }}
         run: |
@@ -34,6 +31,11 @@ jobs:
 
           if [ -z "${RUSTFS_ENDPOINT}" ]; then
             echo "RUSTFS_S3_ENDPOINT secret is required"
+            exit 1
+          fi
+
+          if [ -z "${AWS_ACCESS_KEY_ID}" ] || [ -z "${AWS_SECRET_ACCESS_KEY}" ] || [ -z "${AWS_DEFAULT_REGION}" ]; then
+            echo "RUSTFS credentials/region secrets are required"
             exit 1
           fi
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zephyr",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "license": "AGPL-3.0",
   "homepage": "https://zephyyrr.in",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zephyr",
-  "version": "1.0.27",
+  "version": "1.0.28",
   "license": "AGPL-3.0",
   "homepage": "https://zephyyrr.in",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zephyr",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "license": "AGPL-3.0",
   "homepage": "https://zephyyrr.in",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zephyr",
-  "version": "1.0.26",
+  "version": "1.0.27",
   "license": "AGPL-3.0",
   "homepage": "https://zephyyrr.in",
   "private": true,


### PR DESCRIPTION
## Summary
- finalize Prisma safe-sync command for Dokploy runtime by generating an inline Prisma config at runtime
- resolve DB URL from available envs (`DATABASE_URL` fallback chain) and export it for Prisma CLI
- improve Dokploy run API handling to capture/print HTTP + response body before failing

## Why
- previous main run failed in Prisma safe sync due to Prisma config/schema lookup issues inside Dokploy app container

## Validation
- actionlint
- bun run check
- bun run check-types
- pre-push hooks (unit tests + typecheck) passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zephverse/codesmith/zephyr/pr/40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 1.0.29
  * CI/CD workflow infrastructure improvements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->