### PR TITLE
Potential fix for code scanning alert no. 15: Server-side request forgery

### DIFF
--- a/apps/web/src/app/api/verify-email/route.ts
+++ b/apps/web/src/app/api/verify-email/route.ts
@@ -151,7 +151,7 @@ export async function GET(req: NextRequest) {
   try {
     try {
       const sessionRes = await fetch(
-        `${req.nextUrl.origin}/api/auth/get-session`,
+        `${authBase}/api/auth/get-session`,
         {
           headers: {
             cookie: req.headers.get("cookie") ?? "",


### PR DESCRIPTION
Potential fix for [https://github.com/zephverse/zephyr/security/code-scanning/15](https://github.com/zephverse/zephyr/security/code-scanning/15)

Use a **trusted, server-controlled base URL** instead of `req.nextUrl.origin` when constructing the internal session-check URL.

Best fix without changing functionality:
- In `apps/web/src/app/api/verify-email/route.ts`, replace:
  - `` `${req.nextUrl.origin}/api/auth/get-session` ``
  with:
  - `` `${authBase}/api/auth/get-session` ``
- Keep existing behavior (same endpoint/path, same headers/cookie forwarding), but remove user influence over hostname/protocol.
- No new imports/dependencies needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zephverse/codesmith/zephyr/pr/41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->